### PR TITLE
Standup script

### DIFF
--- a/setup_demo.sh
+++ b/setup_demo.sh
@@ -38,8 +38,28 @@ function check_time() {
 
 KUBE_RANDOM=$(petname)
 JENK_RANDOM=$(petname)
-juju add-model jenkins-${JENK_RANDOM} google/us-central1 --credential=work
-juju add-model kubernetes-${KUBE_RANDOM} google/us-central1 --credential=work
+
+# READ cloud/region, and optional credential
+echo "Enter your cloud of choice (eg: google/us-central1)"
+read USER_CLOUD
+
+# Cloud is required
+if [ -z "${USER_CLOUD}" ]; then
+    echo "Missing cloud details."
+    exit 1
+fi
+
+
+# Credential is optional
+echo "[optional] Enter your credential (eg: work):"
+read USER_CREDENTIAL
+
+if [ ! -z "${USER_CREDENTIAL}" ]; then
+   CLOUD_CREDENTIAL="--credential=${USER_CREDENTIAL}"
+fi
+
+juju add-model jenkins-${JENK_RANDOM} ${USER_CLOUD} ${CLOUD_CREDENTIAL}
+juju add-model kubernetes-${KUBE_RANDOM} ${USER_CLOUD} ${CLOUD_CREDENTIAL}
 
 juju switch kubernetes-${KUBE_RANDOM}
 juju deploy canonical-kubernetes

--- a/setup_demo.sh
+++ b/setup_demo.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -e
+sudo apt-get install -y petname
+
+# Shamelessly ripped from juju-solutions/kubernetes-jenkins repository
+
+MAXIMUM_WAIT_SECONDS=3600
+
+# Run a command in a loop waiting for specific output use MAXIMUM_WAIT_SECONDS.
+function run_and_wait() {
+  local cmd=$1
+  local match=$2
+  local sleep_seconds=${3:-5}
+  local start_time=`date +"%s"`
+  # Run the command in a loop looking for output.
+  until $(${cmd} | grep -q "${match}"); do 
+    # Check the time so this does not loop forever.
+    check_time ${start_time} ${MAXIMUM_WAIT_SECONDS}
+    sleep ${sleep_seconds}
+  done
+}
+
+
+# The check_time function requires two parameters start_time and max_seconds.
+function check_time() {
+  local start_time=$1
+  local maximum_seconds=$2
+  local current_time=`date +"%s"`
+  local difference=$(expr ${current_time} - ${start_time})
+  # When the difference is greater than maximum seconds, exit this script.
+  if [[ ${difference} -gt ${maximum_seconds} ]]; then
+    echo "The process is taking more than ${maximum_seconds} seconds!"
+    # End this script because too much time has passed.
+    exit 3
+  fi
+}
+
+KUBE_RANDOM=$(petname)
+JENK_RANDOM=$(petname)
+juju add-model jenkins-${JENK_RANDOM} google/us-central1 --credential=work
+juju add-model kubernetes-${KUBE_RANDOM} google/us-central1 --credential=work
+
+juju switch kubernetes-${KUBE_RANDOM}
+juju deploy canonical-kubernetes
+
+juju switch jenkins-${JENK_RANDOM}
+juju deploy bundle.yaml
+
+echo "What jenkins admin password?"
+read JENK_PASSWORD
+
+juju config jenkins password=$JENK_PASSWORD
+
+if [ ! -f './workspaces/workspace.tgz' ]; then
+ "Creating workspace archive"
+ cd workspaces
+ tar cvfz workspace.tgz *
+ cd ..
+fi
+echo "attaching workspace resource"
+set +e
+# This is known to fail, so try until it succeeds
+
+until juju attach jenkins-workspace workspace=workspaces/workspace.tgz
+do
+  echo "Attach not successful, retrying in 3 seconds."
+  sleep 3
+done
+
+# When deployment is complete, run copy_kubernetes_credentials.sh
+run_and_wait "juju status -m kubernetes-${KUBE_RANDOM}" "Kubernetes master running" 15
+
+echo "Inserting kubernetes credentials"
+./copy_kubernetes_credentials.sh kubernetes-${KUBE_RANDOM}
+
+echo "Dont forget to enlist dockerhub password in the job!"

--- a/setup_demo.sh
+++ b/setup_demo.sh
@@ -73,10 +73,10 @@ read JENK_PASSWORD
 juju config jenkins password=$JENK_PASSWORD
 
 if [ ! -f './workspaces/workspace.tgz' ]; then
- "Creating workspace archive"
- cd workspaces
- tar cvfz workspace.tgz *
- cd ..
+   echo "Creating workspace archive"
+   cd workspaces
+   tar cvfz workspace.tgz *
+   cd ..
 fi
 echo "attaching workspace resource"
 set +e
@@ -87,6 +87,7 @@ do
   echo "Attach not successful, retrying in 3 seconds."
   sleep 3
 done
+set -e
 
 # When deployment is complete, run copy_kubernetes_credentials.sh
 run_and_wait "juju status -m kubernetes-${KUBE_RANDOM}" "Kubernetes master running" 15

--- a/setup_demo.sh
+++ b/setup_demo.sh
@@ -68,7 +68,7 @@ juju switch jenkins-${JENK_RANDOM}
 juju deploy bundle.yaml
 
 echo "What jenkins admin password?"
-read JENK_PASSWORD
+read -s JENK_PASSWORD
 
 juju config jenkins password=$JENK_PASSWORD
 


### PR DESCRIPTION
adds setup_demo.sh which

Deploys 2 models

1) kubernetes-$random_name
2) jenkins-$random_name

This will generate the tar package for the jenkins workspace from the repository, and then attach to the jenkins-workspace charm

Additionally it waits until the k8s master unit is ready and then runs the copy_credentials script, and prompts the user to remember to setup the dockerhub login.

Feedback welcome